### PR TITLE
Basis for npf-checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,129 @@
+*.nest
+*.nest.new
+*.toml
+cache/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+from core.pushd import pushd

--- a/core/args.py
+++ b/core/args.py
@@ -27,20 +27,7 @@ def parse_args():
         ),
         help="Cache directory used to unpack and check the NPF. Default: cache/",
     )
-    _parser.add_argument(
-        '-o',
-        '--output',
-        default=None,
-        help="Output NPF file, by default it replaces the given one",
-    )
-    _parser.add_argument(
-        '--backup',
-        default=None,
-        help="If no -o/--output is given, this creates a backup, default is {npf}.bak",
-    )
     _args = _parser.parse_args()
-    _args.output = _args.output or _args.npf
-    _args.backup = _args.backup or f"{_args.npf}.bak"
 
 
 def get_args():

--- a/core/args.py
+++ b/core/args.py
@@ -1,0 +1,53 @@
+import argparse
+import os
+import sys
+
+global _args
+global _parser
+
+
+def parse_args():
+    global _args
+    global _parser
+
+    _parser = argparse.ArgumentParser(
+        description="A checker that ensure the validity and conformance of an NPF",
+    )
+    _parser.add_argument(
+        'npf',
+        nargs='+',
+    )
+    _parser.add_argument(
+        '-c',
+        '--cache-dir',
+        default=os.path.join(
+            os.getcwd(),
+            os.path.dirname(sys.argv[0]),
+            'cache',
+        ),
+        help="Cache directory used to unpack and check the NPF. Default: cache/",
+    )
+    _parser.add_argument(
+        '-o',
+        '--output',
+        default=None,
+        help="Output NPF file, by default it replaces the given one",
+    )
+    _parser.add_argument(
+        '--backup',
+        default=None,
+        help="If no -o/--output is given, this creates a backup, default is {npf}.bak",
+    )
+    _args = _parser.parse_args()
+    _args.output = _args.output or _args.npf
+    _args.backup = _args.backup or f"{_args.npf}.bak"
+
+
+def get_args():
+    global _args
+    return _args
+
+
+def get_parser():
+    global _parser
+    return _parser

--- a/core/log.py
+++ b/core/log.py
@@ -1,0 +1,90 @@
+"""
+Functions to write and manipulate logs.
+"""
+
+import termcolor
+from contextlib import contextmanager
+
+log_tab_level = 0
+
+
+@contextmanager
+def push():
+    """Increase the log indentation level by one, making every new line indented by one extra tabulation."""
+    global log_tab_level
+    log_tab_level += 1
+
+    try:
+        yield
+    finally:
+        log_tab_level -= 1
+
+
+def d(*logs: str):
+    """Print a debug log, prefixed by a magenta ``[d]``.
+    :param logs: The content of the log.
+    """
+    global log_tab_level
+
+    indent = '    ' * log_tab_level
+    print(f"{termcolor.colored('[d]', 'magenta', attrs=['bold'])} {indent}", *logs)
+
+
+def i(*logs: str):
+    """Print an informative log, prefixed by a blue ``[*]``.
+    :param logs: The content of the log.
+    """
+    global log_tab_level
+
+    indent = '    ' * log_tab_level
+    print(f"{termcolor.colored('[*]', 'blue', attrs=['bold'])} {indent}", *logs)
+
+
+def s(*logs: str):
+    """Print a success log, prefixed by a green ``[+]``.
+    :param logs: The content of the log.
+    """
+    global log_tab_level
+
+    indent = '    ' * log_tab_level
+    print(f"{termcolor.colored('[+]', 'green', attrs=['bold'])} {indent}", *logs)
+
+
+def w(*logs: str):
+    """Print a warning log, prefixed by a yellow ``[!]``.
+    :param logs: The content of the log.
+    """
+    global log_tab_level
+
+    indent = '    ' * log_tab_level
+    print(f"{termcolor.colored('[!]', 'yellow', attrs=['bold'])} {indent}", *logs)
+
+
+def e(*logs: str):
+    """Print a non-fatal error log, prefixed by a red ``[-]``.
+    :param logs: The content of the log.
+    """
+    global log_tab_level
+
+    indent = '    ' * log_tab_level
+    print(f"{termcolor.colored('[-]', 'red', attrs=['bold'])} {indent}", *logs)
+
+
+def f(*logs: str):
+    """Print a fatal error log, all in red, prefixed by ``[-]``.
+    :info: This function does NOT abort the current process's execution.
+    :param logs: The content of the log.
+    """
+    termcolor.cprint(f"[-]  {' '.join(logs)}", 'red', attrs=['bold'])
+
+
+def q(*logs: str):
+    """Print a question, prefixed by a yellow ``[?]`` and waits for user input.
+    :param logs: The content of the log.
+    :returns: The string returned by ``input()``
+    """
+    global log_tab_level
+
+    indent = '\t' * log_tab_level
+    print(f"{termcolor.colored('[?]', 'yellow')} {indent}", *logs, end='')
+    return input()

--- a/core/package.py
+++ b/core/package.py
@@ -9,6 +9,7 @@ class Package:
     def __init__(self, npf_path):
         self.cache = core.args.get_args().cache_dir
         self.npf_path = npf_path
+        self.is_effective = False
 
     def unwrap(self):
         if os.path.exists(self.cache):
@@ -18,8 +19,43 @@ class Package:
             tar.extractall(self.cache)
         self.manifest_path = os.path.join(self.cache, 'manifest.toml')
         self.manifest = toml.load(self.manifest_path)
+        self.is_effective = self.manifest['kind'] == 'effective'
         data = os.path.join(self.cache, 'data.tar.gz')
         if os.path.exists(data):
             with tarfile.open(data, 'r:gz') as tar:
                 tar.extractall(self.cache)
             os.remove(data)
+
+    def check(self):
+        print('TODO: Package.check()')
+
+    def wrap(self):
+        self.create_manifest_toml()
+        if self.is_effective:
+            self.create_data_tar()
+        self.create_nest_file()
+
+    def create_manifest_toml(self):
+        print('TODO: Package.create_manifest_toml()')
+        pass
+
+    def create_data_tar(self):
+        with core.pushd(self.cache):
+            for root, _, filenames in os.walk('.'):
+                for name in filenames:
+                    print(os.path.join(root, name))
+            with tarfile.open('data.tar.gz', 'w:gz') as archive:
+                archive.add('./')
+
+    def create_nest_file(self):
+        with core.pushd(self.cache):
+            new_nest_file_path = os.path.basename(self.npf_path) + '.new'
+            with tarfile.open(new_nest_file_path, 'w') as nest_file:
+                nest_file.add('manifest.toml')
+                if self.is_effective:
+                    nest_file.add('data.tar.gz')
+            os.remove('manifest.toml')
+            if self.is_effective:
+                os.remove('data.tar.gz')
+        new_path = f'{self.npf_path}.new'
+        os.rename(os.path.join(self.cache, new_nest_file_path), new_path)

--- a/core/package.py
+++ b/core/package.py
@@ -1,8 +1,9 @@
 import shutil
 import os
 import tarfile
-import core
 import toml
+import datetime
+import core
 
 
 class Package:
@@ -30,14 +31,15 @@ class Package:
         print('TODO: Package.check()')
 
     def wrap(self):
-        self.create_manifest_toml()
+        self.update_manifest_toml_wrap_date()
         if self.is_effective:
             self.create_data_tar()
         self.create_nest_file()
 
-    def create_manifest_toml(self):
-        print('TODO: Package.create_manifest_toml()')
-        pass
+    def update_manifest_toml_wrap_date(self):
+        self.manifest['wrap_date'] = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + 'Z'
+        with open(self.manifest_path, 'w') as filename:
+            toml.dump(self.manifest, filename)
 
     def create_data_tar(self):
         with core.pushd(self.cache):

--- a/core/package.py
+++ b/core/package.py
@@ -2,13 +2,7 @@ import shutil
 import os
 import tarfile
 import core
-import enum
 import toml
-
-
-class Kind(enum.Enum):
-    EFFECTIVE = 'effective'
-    VIRTUAL = 'virtual'
 
 
 class Package:

--- a/core/package.py
+++ b/core/package.py
@@ -1,0 +1,31 @@
+import shutil
+import os
+import tarfile
+import core
+import enum
+import toml
+
+
+class Kind(enum.Enum):
+    EFFECTIVE = 'effective'
+    VIRTUAL = 'virtual'
+
+
+class Package:
+    def __init__(self, npf_path):
+        self.cache = core.args.get_args().cache_dir
+        self.npf_path = npf_path
+
+    def unwrap(self):
+        if os.path.exists(self.cache):
+            shutil.rmtree(self.cache)
+        os.makedirs(self.cache)
+        with tarfile.open(self.npf_path, 'r') as tar:
+            tar.extractall(self.cache)
+        self.manifest_path = os.path.join(self.cache, 'manifest.toml')
+        self.manifest = toml.load(self.manifest_path)
+        data = os.path.join(self.cache, 'data.tar.gz')
+        if os.path.exists(data):
+            with tarfile.open(data, 'r:gz') as tar:
+                tar.extractall(self.cache)
+            os.remove(data)

--- a/core/pushd.py
+++ b/core/pushd.py
@@ -1,0 +1,12 @@
+import os
+import contextlib
+
+
+@contextlib.contextmanager
+def pushd(path: str = '.'):
+    old_path = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old_path)

--- a/npf-checker.py
+++ b/npf-checker.py
@@ -10,6 +10,8 @@ def main():
     for f in args.npf:
         pkg = core.package.Package(f)
         pkg.unwrap()
+        pkg.check()
+        pkg.wrap()
 
 
 if __name__ == '__main__':

--- a/npf-checker.py
+++ b/npf-checker.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import core.args
+import core.package
+
+
+def main():
+    core.args.parse_args()
+    args = core.args.get_args()
+    for f in args.npf:
+        pkg = core.package.Package(f)
+        pkg.unwrap()
+
+
+if __name__ == '__main__':
+    main()

--- a/npf-checker.py
+++ b/npf-checker.py
@@ -2,6 +2,7 @@
 
 import core.args
 import core.package
+import core.log as log
 
 
 def main():
@@ -9,8 +10,11 @@ def main():
     args = core.args.get_args()
     for f in args.npf:
         pkg = core.package.Package(f)
+        log.s(f"Unwrapping {f}")
         pkg.unwrap()
+        log.s(f"Checking {f}")
         pkg.check()
+        log.s(f"Wrapping {f}")
         pkg.wrap()
 
 


### PR DESCRIPTION
At the moment, `npf-checker` only takes NPFs, unwraps them, and wraps them again.
This contains nothing about the checks themselves.
- `core/pushd` has been taken from `nbuild`
- `core/log` has been taken from `nbuild`, with a few modifications
    - the functions don't have `log` in their name anymore (i.e. `dlog` is now `d`, `pushlog` is now `push`, etc). This is to force the use of `import X` instead of `from X import Y`
    - The `q` function has been added, it is used to ask a question to the user, reading from standard input and returning the result
- During the wrap phase, the parts that show the content of `manifest.toml` and the files added to `data.tar.gz` have been taken from `nbuild` as well.

(This is to alleviate the work needed from reviewers, as these parts from `nbuild` should have already been reviewed)
